### PR TITLE
feat: auto-fill key name with selected file name in put window

### DIFF
--- a/mutant-web/src/app/put.rs
+++ b/mutant-web/src/app/put.rs
@@ -265,6 +265,7 @@ impl PutWindow {
         let selected_file = self.selected_file.clone();
         let file_size = self.file_size.clone();
         let file_data = self.file_data.clone();
+        let key_name = self.key_name.clone();
 
         // Create a file input element
         let window = web_sys::window().expect("no global window exists");
@@ -305,6 +306,15 @@ impl PutWindow {
                 // Update state with file name and size
                 *selected_file.write().unwrap() = Some(file_name.clone());
                 *file_size.write().unwrap() = Some(file_size_js as u64);
+
+                // Auto-fill key name if it's empty
+                {
+                    let mut key_name_guard = key_name.write().unwrap();
+                    if key_name_guard.is_empty() {
+                        *key_name_guard = file_name.clone();
+                        log::info!("Auto-filled key name with file name: {}", file_name);
+                    }
+                }
 
                 // Read file content
                 let reader = FileReader::new().expect("failed to create FileReader");


### PR DESCRIPTION
## Summary

Implements auto-fill functionality for the key name field in the put window when a file is selected.

## Changes

- **Auto-fill logic**: When a file is selected and the key name field is empty, automatically populate it with the selected file name
- **User-friendly behavior**: Only auto-fills when the field is empty, preserving any existing user input
- **Logging**: Added debug logging to track when auto-fill occurs

## Implementation Details

- Modified `select_file()` method in `mutant-web/src/app/put.rs`
- Added key_name reference to the file selection closure
- Implemented conditional auto-fill logic that checks if key name is empty before filling

## Testing

### Manual Testing Steps
1. Open the put window in the web application
2. Ensure the key name field is empty
3. Click "Select File" and choose a file
4. Verify that the key name field is automatically populated with the file name
5. Test that manually entering a key name first prevents auto-fill from overwriting it

### Expected Behavior
- ✅ Auto-fills key name when field is empty
- ✅ Preserves existing key name when field has content
- ✅ Logs auto-fill action for debugging

## Benefits

- **Improved UX**: Reduces manual input required from users
- **Conservative approach**: Doesn't interfere with existing user workflows
- **Maintains flexibility**: Users can still manually set custom key names

Fixes the user request to auto-fill the key name with the selected file name when the key name field is empty.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author