### PR TITLE
feat: modernize Stats window with professional dark theme

### DIFF
--- a/mutant-web/src/app/stats.rs
+++ b/mutant-web/src/app/stats.rs
@@ -1,4 +1,4 @@
-use eframe::egui::{self, Color32, RichText, Ui};
+use eframe::egui::{self, Color32, RichText, Ui, Stroke};
 use log;
 use mutant_protocol::StatsResponse;
 use serde::{Deserialize, Serialize};
@@ -6,6 +6,7 @@ use std::sync::{Arc, RwLock};
 use wasm_bindgen_futures;
 
 use super::Window;
+use super::theme::{self, MutantColors};
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct StatsWindow {
@@ -62,11 +63,17 @@ impl StatsWindow {
 
     fn draw_header(&mut self, ui: &mut Ui) {
         ui.horizontal(|ui| {
-            ui.heading("📊 Storage Statistics");
+            // Modern title with accent color
+            ui.label(
+                RichText::new("Storage Statistics")
+                    .size(18.0)
+                    .strong()
+                    .color(MutantColors::TEXT_PRIMARY)
+            );
 
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                // Refresh button
-                if ui.button("🔄 Refresh").clicked() {
+                // Modern styled refresh button
+                if ui.add(theme::styled_button("Refresh", MutantColors::ACCENT_BLUE)).clicked() {
                     self.refresh_stats();
                 }
             });
@@ -75,30 +82,72 @@ impl StatsWindow {
 
     fn draw_error(&self, ui: &mut Ui, error: &str) {
         ui.vertical_centered(|ui| {
-            ui.add_space(50.0);
-            ui.label(RichText::new("⚠️ Error").size(24.0).color(Color32::RED));
-            ui.add_space(10.0);
-            ui.label(RichText::new(error).color(Color32::LIGHT_RED));
-            ui.add_space(20.0);
-            ui.label("Try refreshing or check if the daemon is running.");
+            ui.add_space(40.0);
+
+            // Modern error display with themed colors
+            ui.label(
+                RichText::new("Connection Error")
+                    .size(16.0)
+                    .strong()
+                    .color(MutantColors::ERROR)
+            );
+            ui.add_space(8.0);
+
+            // Error message in a subtle frame
+            egui::Frame::new()
+                .fill(MutantColors::SURFACE)
+                .stroke(Stroke::new(1.0, MutantColors::ERROR))
+                .corner_radius(6.0)
+                .inner_margin(12.0)
+                .show(ui, |ui| {
+                    ui.label(
+                        RichText::new(error)
+                            .size(13.0)
+                            .color(MutantColors::TEXT_SECONDARY)
+                    );
+                });
+
+            ui.add_space(12.0);
+            ui.label(
+                RichText::new("Try refreshing or check if the daemon is running.")
+                    .size(12.0)
+                    .color(MutantColors::TEXT_MUTED)
+            );
         });
     }
 
     fn draw_loading(&self, ui: &mut Ui) {
         ui.vertical_centered(|ui| {
-            ui.add_space(50.0);
-            ui.label(RichText::new("⏳ Loading...").size(20.0));
-            ui.add_space(10.0);
-            ui.spinner();
+            ui.add_space(60.0);
+
+            // Modern loading display
+            ui.label(
+                RichText::new("Loading Statistics...")
+                    .size(16.0)
+                    .color(MutantColors::TEXT_SECONDARY)
+            );
+            ui.add_space(12.0);
+
+            // Themed spinner
+            ui.add(egui::Spinner::new().size(24.0).color(MutantColors::ACCENT_BLUE));
         });
     }
 
     fn draw_no_data(&self, ui: &mut Ui) {
         ui.vertical_centered(|ui| {
-            ui.add_space(50.0);
-            ui.label(RichText::new("📊 No Data").size(20.0));
-            ui.add_space(10.0);
-            ui.label("Click refresh to load statistics.");
+            ui.add_space(60.0);
+
+            ui.label(
+                RichText::new("No Statistics Available")
+                    .size(16.0)
+                    .color(MutantColors::TEXT_SECONDARY)
+            );
+            ui.add_space(8.0);
+            ui.label(
+                RichText::new("Click refresh to load statistics.")
+                    .size(13.0)
+                    .color(MutantColors::TEXT_MUTED)
+            );
         });
     }
 
@@ -120,159 +169,227 @@ impl StatsWindow {
     }
 
     fn draw_overview_section(&self, ui: &mut Ui, stats: &StatsResponse) {
-        ui.group(|ui| {
-            ui.vertical(|ui| {
-                ui.label(RichText::new("📋 Overview").size(16.0).strong());
-                ui.separator();
-                ui.add_space(5.0);
+        // Modern section with themed styling
+        egui::Frame::new()
+            .fill(MutantColors::SURFACE)
+            .stroke(Stroke::new(1.0, MutantColors::BORDER_MEDIUM))
+            .corner_radius(8.0)
+            .inner_margin(16.0)
+            .show(ui, |ui| {
+                ui.vertical(|ui| {
+                    // Section header with accent color
+                    ui.label(
+                        RichText::new("Overview")
+                            .size(15.0)
+                            .strong()
+                            .color(MutantColors::ACCENT_ORANGE)
+                    );
 
-                ui.horizontal(|ui| {
-                    self.draw_stat_card(ui, "🔑 Total Keys", &stats.total_keys.to_string(), Color32::from_rgb(100, 150, 255));
-                    ui.add_space(10.0);
-                    self.draw_stat_card(ui, "📦 Total Pads", &stats.total_pads.to_string(), Color32::from_rgb(150, 100, 255));
+                    ui.add_space(8.0);
+                    ui.separator();
+                    ui.add_space(12.0);
+
+                    ui.horizontal(|ui| {
+                        self.draw_modern_stat_card(ui, "Total Keys", &stats.total_keys.to_string(), MutantColors::ACCENT_BLUE);
+                        ui.add_space(12.0);
+                        self.draw_modern_stat_card(ui, "Total Pads", &stats.total_pads.to_string(), MutantColors::ACCENT_PURPLE);
+                    });
                 });
             });
-        });
     }
 
     fn draw_pads_section(&self, ui: &mut Ui, stats: &StatsResponse) {
-        ui.group(|ui| {
-            ui.vertical(|ui| {
-                ui.label(RichText::new("📦 Pads Breakdown").size(16.0).strong());
-                ui.separator();
-                ui.add_space(5.0);
+        egui::Frame::new()
+            .fill(MutantColors::SURFACE)
+            .stroke(Stroke::new(1.0, MutantColors::BORDER_MEDIUM))
+            .corner_radius(8.0)
+            .inner_margin(16.0)
+            .show(ui, |ui| {
+                ui.vertical(|ui| {
+                    // Section header
+                    ui.label(
+                        RichText::new("Pads Breakdown")
+                            .size(15.0)
+                            .strong()
+                            .color(MutantColors::ACCENT_ORANGE)
+                    );
 
-                // Calculate percentages
-                let total_pads = stats.total_pads as f32;
-                let occupied_pct = if total_pads > 0.0 { (stats.occupied_pads as f32 / total_pads) * 100.0 } else { 0.0 };
-                let free_pct = if total_pads > 0.0 { (stats.free_pads as f32 / total_pads) * 100.0 } else { 0.0 };
-                let pending_pct = if total_pads > 0.0 { (stats.pending_verify_pads as f32 / total_pads) * 100.0 } else { 0.0 };
+                    ui.add_space(8.0);
+                    ui.separator();
+                    ui.add_space(12.0);
 
-                ui.horizontal(|ui| {
-                    self.draw_stat_card_with_percentage(
-                        ui,
-                        "🟢 Occupied",
-                        &stats.occupied_pads.to_string(),
-                        occupied_pct,
-                        Color32::from_rgb(100, 200, 100)
-                    );
-                    ui.add_space(10.0);
-                    self.draw_stat_card_with_percentage(
-                        ui,
-                        "⚪ Free",
-                        &stats.free_pads.to_string(),
-                        free_pct,
-                        Color32::from_rgb(200, 200, 200)
-                    );
-                    ui.add_space(10.0);
-                    self.draw_stat_card_with_percentage(
-                        ui,
-                        "🟡 Pending",
-                        &stats.pending_verify_pads.to_string(),
-                        pending_pct,
-                        Color32::from_rgb(255, 200, 100)
-                    );
+                    // Calculate percentages
+                    let total_pads = stats.total_pads as f32;
+                    let occupied_pct = if total_pads > 0.0 { (stats.occupied_pads as f32 / total_pads) * 100.0 } else { 0.0 };
+                    let free_pct = if total_pads > 0.0 { (stats.free_pads as f32 / total_pads) * 100.0 } else { 0.0 };
+                    let pending_pct = if total_pads > 0.0 { (stats.pending_verify_pads as f32 / total_pads) * 100.0 } else { 0.0 };
+
+                    ui.horizontal(|ui| {
+                        self.draw_modern_stat_card_with_percentage(
+                            ui,
+                            "Occupied",
+                            &stats.occupied_pads.to_string(),
+                            occupied_pct,
+                            MutantColors::ACCENT_GREEN
+                        );
+                        ui.add_space(12.0);
+                        self.draw_modern_stat_card_with_percentage(
+                            ui,
+                            "Free",
+                            &stats.free_pads.to_string(),
+                            free_pct,
+                            MutantColors::TEXT_SECONDARY
+                        );
+                        ui.add_space(12.0);
+                        self.draw_modern_stat_card_with_percentage(
+                            ui,
+                            "Pending",
+                            &stats.pending_verify_pads.to_string(),
+                            pending_pct,
+                            MutantColors::WARNING
+                        );
+                    });
+
+                    ui.add_space(16.0);
+
+                    // Modern usage bar
+                    self.draw_modern_usage_bar(ui, stats);
                 });
-
-                ui.add_space(10.0);
-
-                // Visual progress bar for pad usage
-                self.draw_usage_bar(ui, stats);
             });
-        });
     }
 
     fn draw_efficiency_section(&self, ui: &mut Ui, stats: &StatsResponse) {
-        ui.group(|ui| {
-            ui.vertical(|ui| {
-                ui.label(RichText::new("📈 Storage Efficiency").size(16.0).strong());
-                ui.separator();
-                ui.add_space(5.0);
-
-                let total_pads = stats.total_pads as f32;
-                let utilization = if total_pads > 0.0 {
-                    (stats.occupied_pads as f32 / total_pads) * 100.0
-                } else {
-                    0.0
-                };
-
-                let avg_pads_per_key = if stats.total_keys > 0 {
-                    stats.occupied_pads as f32 / stats.total_keys as f32
-                } else {
-                    0.0
-                };
-
-                ui.horizontal(|ui| {
-                    self.draw_stat_card(
-                        ui,
-                        "📊 Utilization",
-                        &format!("{:.1}%", utilization),
-                        if utilization > 80.0 { Color32::from_rgb(255, 100, 100) }
-                        else if utilization > 60.0 { Color32::from_rgb(255, 200, 100) }
-                        else { Color32::from_rgb(100, 200, 100) }
+        egui::Frame::new()
+            .fill(MutantColors::SURFACE)
+            .stroke(Stroke::new(1.0, MutantColors::BORDER_MEDIUM))
+            .corner_radius(8.0)
+            .inner_margin(16.0)
+            .show(ui, |ui| {
+                ui.vertical(|ui| {
+                    // Section header
+                    ui.label(
+                        RichText::new("Storage Efficiency")
+                            .size(15.0)
+                            .strong()
+                            .color(MutantColors::ACCENT_ORANGE)
                     );
-                    ui.add_space(10.0);
-                    self.draw_stat_card(
-                        ui,
-                        "🔢 Avg Pads/Key",
-                        &format!("{:.1}", avg_pads_per_key),
-                        Color32::from_rgb(150, 150, 255)
-                    );
+
+                    ui.add_space(8.0);
+                    ui.separator();
+                    ui.add_space(12.0);
+
+                    let total_pads = stats.total_pads as f32;
+                    let utilization = if total_pads > 0.0 {
+                        (stats.occupied_pads as f32 / total_pads) * 100.0
+                    } else {
+                        0.0
+                    };
+
+                    let avg_pads_per_key = if stats.total_keys > 0 {
+                        stats.occupied_pads as f32 / stats.total_keys as f32
+                    } else {
+                        0.0
+                    };
+
+                    ui.horizontal(|ui| {
+                        self.draw_modern_stat_card(
+                            ui,
+                            "Utilization",
+                            &format!("{:.1}%", utilization),
+                            if utilization > 80.0 { MutantColors::ERROR }
+                            else if utilization > 60.0 { MutantColors::WARNING }
+                            else { MutantColors::ACCENT_GREEN }
+                        );
+                        ui.add_space(12.0);
+                        self.draw_modern_stat_card(
+                            ui,
+                            "Avg Pads/Key",
+                            &format!("{:.1}", avg_pads_per_key),
+                            MutantColors::ACCENT_CYAN
+                        );
+                    });
                 });
             });
-        });
     }
 
-    fn draw_stat_card(&self, ui: &mut Ui, label: &str, value: &str, color: Color32) {
+    fn draw_modern_stat_card(&self, ui: &mut Ui, label: &str, value: &str, accent_color: Color32) {
         let available_width = ui.available_width();
-        let card_width = (available_width - 20.0) / 2.0; // Account for spacing
+        let card_width = (available_width - 12.0) / 2.0; // Account for spacing
 
         ui.allocate_ui_with_layout(
-            egui::vec2(card_width, 80.0),
+            egui::vec2(card_width, 70.0),
             egui::Layout::top_down(egui::Align::Center),
             |ui| {
                 egui::Frame::new()
-                    .fill(color.gamma_multiply(0.1))
-                    .stroke(egui::Stroke::new(1.0, color))
-                    .corner_radius(8.0)
-                    .inner_margin(10.0)
+                    .fill(MutantColors::BACKGROUND_LIGHT)
+                    .stroke(Stroke::new(1.0, MutantColors::BORDER_LIGHT))
+                    .corner_radius(6.0)
+                    .inner_margin(12.0)
                     .show(ui, |ui| {
                         ui.vertical_centered(|ui| {
-                            ui.label(RichText::new(label).size(12.0).color(Color32::GRAY));
-                            ui.label(RichText::new(value).size(20.0).strong().color(color));
+                            ui.label(
+                                RichText::new(label)
+                                    .size(11.0)
+                                    .color(MutantColors::TEXT_MUTED)
+                            );
+                            ui.add_space(4.0);
+                            ui.label(
+                                RichText::new(value)
+                                    .size(18.0)
+                                    .strong()
+                                    .color(accent_color)
+                            );
                         });
                     });
             }
         );
     }
 
-    fn draw_stat_card_with_percentage(&self, ui: &mut Ui, label: &str, value: &str, percentage: f32, color: Color32) {
+    fn draw_modern_stat_card_with_percentage(&self, ui: &mut Ui, label: &str, value: &str, percentage: f32, accent_color: Color32) {
         let available_width = ui.available_width();
-        let card_width = (available_width - 20.0) / 3.0; // Account for spacing, 3 cards
+        let card_width = (available_width - 24.0) / 3.0; // Account for spacing, 3 cards
 
         ui.allocate_ui_with_layout(
-            egui::vec2(card_width, 80.0),
+            egui::vec2(card_width, 75.0),
             egui::Layout::top_down(egui::Align::Center),
             |ui| {
                 egui::Frame::new()
-                    .fill(color.gamma_multiply(0.1))
-                    .stroke(egui::Stroke::new(1.0, color))
-                    .corner_radius(8.0)
+                    .fill(MutantColors::BACKGROUND_LIGHT)
+                    .stroke(Stroke::new(1.0, MutantColors::BORDER_LIGHT))
+                    .corner_radius(6.0)
                     .inner_margin(10.0)
                     .show(ui, |ui| {
                         ui.vertical_centered(|ui| {
-                            ui.label(RichText::new(label).size(12.0).color(Color32::GRAY));
-                            ui.label(RichText::new(value).size(18.0).strong().color(color));
-                            ui.label(RichText::new(format!("{:.1}%", percentage)).size(10.0).color(Color32::GRAY));
+                            ui.label(
+                                RichText::new(label)
+                                    .size(11.0)
+                                    .color(MutantColors::TEXT_MUTED)
+                            );
+                            ui.add_space(2.0);
+                            ui.label(
+                                RichText::new(value)
+                                    .size(16.0)
+                                    .strong()
+                                    .color(accent_color)
+                            );
+                            ui.label(
+                                RichText::new(format!("{:.1}%", percentage))
+                                    .size(10.0)
+                                    .color(MutantColors::TEXT_SECONDARY)
+                            );
                         });
                     });
             }
         );
     }
 
-    fn draw_usage_bar(&self, ui: &mut Ui, stats: &StatsResponse) {
-        ui.label(RichText::new("Pad Usage Distribution").size(12.0).color(Color32::GRAY));
-        ui.add_space(5.0);
+    fn draw_modern_usage_bar(&self, ui: &mut Ui, stats: &StatsResponse) {
+        ui.label(
+            RichText::new("Usage Distribution")
+                .size(12.0)
+                .color(MutantColors::TEXT_MUTED)
+        );
+        ui.add_space(8.0);
 
         let total_pads = stats.total_pads as f32;
         if total_pads > 0.0 {
@@ -280,7 +397,15 @@ impl StatsWindow {
             let free_ratio = stats.free_pads as f32 / total_pads;
             let pending_ratio = stats.pending_verify_pads as f32 / total_pads;
 
-            let (rect, _) = ui.allocate_exact_size(egui::vec2(ui.available_width(), 20.0), egui::Sense::hover());
+            // Modern progress bar with rounded corners and subtle styling
+            let (rect, _) = ui.allocate_exact_size(egui::vec2(ui.available_width(), 16.0), egui::Sense::hover());
+
+            // Background
+            ui.painter().rect_filled(
+                rect,
+                8.0,
+                MutantColors::BACKGROUND_DARK
+            );
 
             let mut current_x = rect.min.x;
 
@@ -291,7 +416,7 @@ impl StatsWindow {
                     egui::pos2(current_x, rect.min.y),
                     egui::vec2(width, rect.height())
                 );
-                ui.painter().rect_filled(occupied_rect, 4.0, Color32::from_rgb(100, 200, 100));
+                ui.painter().rect_filled(occupied_rect, 8.0, MutantColors::ACCENT_GREEN);
                 current_x += width;
             }
 
@@ -302,7 +427,7 @@ impl StatsWindow {
                     egui::pos2(current_x, rect.min.y),
                     egui::vec2(width, rect.height())
                 );
-                ui.painter().rect_filled(pending_rect, 4.0, Color32::from_rgb(255, 200, 100));
+                ui.painter().rect_filled(pending_rect, 8.0, MutantColors::WARNING);
                 current_x += width;
             }
 
@@ -313,10 +438,16 @@ impl StatsWindow {
                     egui::pos2(current_x, rect.min.y),
                     egui::vec2(width, rect.height())
                 );
-                ui.painter().rect_filled(free_rect, 4.0, Color32::from_rgb(200, 200, 200));
+                ui.painter().rect_filled(free_rect, 8.0, MutantColors::TEXT_SECONDARY);
             }
 
-            // Note: Border drawing removed to avoid egui version compatibility issues
+            // Subtle border
+            ui.painter().rect_stroke(
+                rect,
+                8.0,
+                Stroke::new(1.0, MutantColors::BORDER_LIGHT),
+                egui::epaint::StrokeKind::Outside
+            );
         }
     }
 

--- a/mutant-web/src/lib.rs
+++ b/mutant-web/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(mapped_lock_guards)]
+
 
 use std::{collections::HashMap, sync::{Arc, RwLock}};
 


### PR DESCRIPTION
- Replace old emoji-heavy design with clean, modern UI matching fs-tree aesthetics
- Implement MutAnt theme colors throughout (ACCENT_ORANGE, SURFACE, BORDER_MEDIUM, etc.)
- Add modern card-based layout with rounded corners and subtle borders
- Improve typography hierarchy with consistent font sizes and colors
- Replace old stat cards with new draw_modern_stat_card methods
- Add professional error/loading states with themed frames and spinners
- Implement modern usage bar with rounded corners and theme colors
- Update header with styled refresh button using theme::styled_button
- Remove unstable feature flag and fix compilation issues
- Replace mapped lock guards with simpler clone-based approach

The Stats window now provides a cohesive, professional experience that seamlessly integrates with the overall MutAnt design language.